### PR TITLE
Update OpenRCT2 Main Website Link

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -5,6 +5,6 @@ html
     link(rel='stylesheet', href='/stylesheets/style.css')
   body
     .wrapper
-      a.brand(href='https://openrct2.website') OpenRCT2
+      a.brand(href='https://openrct2.io') OpenRCT2
       h2 Master Server
       block content


### PR DESCRIPTION
The HTTP(S) page still links to [openrct2.website](https://openrct2.website/), which is currently just a Cloudflare error. This updates that link to [openrct2.io](https://openrct2.io/), which I believe is the current website for the project.